### PR TITLE
Replacing dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Instructions for setting up local development for the CoderDojo Community on Mac
 
 To develop the Community Platform you need the following tools installed:
 
-* [Node.js](http://nodejs.org) version 0.10.38 - ideally installed with [nvm](https://github.com/creationix/nvm) as described in this [article](http://www.nearform.com/nodecrunch/nodejs-sudo-free/). Note that **only** node 0.10.x is supported currently.
+* [Node.js](http://nodejs.org) version 0.10.38 - ideally installed with [nvm](https://github.com/creationix/nvm) as described in this [article](https://www.digitalocean.com/community/tutorials/how-to-install-node-js-with-nvm-node-version-manager-on-a-vps). Note that **only** node 0.10.x is supported currently.
 
 * [PostgreSQL](http://www.postgresql.org/) version 9.4 - see [here](https://wiki.postgresql.org/wiki/Detailed_installation_guides) for installation instructions for your platform. You also may want to install the [pgAdmin](http://www.pgadmin.org/). When PostgreSQL is installed, you need to create a new user (you can do this from pgAdmin 'Login Roles' in the tree):
   * username: platform


### PR DESCRIPTION
The new link is titled How To Install Node.js with NVM (Node Version Manager) on a VPS, but it will work on any unix system. And it's always better than a dead link.