### PR TITLE
added information about a dependency ( postgresql module)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ To develop the Community Platform you need the following tools installed:
 
 * [Node.js](http://nodejs.org) version 0.10.38 - ideally installed with [nvm](https://github.com/creationix/nvm) as described in this [article](https://www.digitalocean.com/community/tutorials/how-to-install-node-js-with-nvm-node-version-manager-on-a-vps). Note that **only** node 0.10.x is supported currently.
 
-* [PostgreSQL](http://www.postgresql.org/) version 9.4 - see [here](https://wiki.postgresql.org/wiki/Detailed_installation_guides) for installation instructions for your platform. You also may want to install the [pgAdmin](http://www.pgadmin.org/). When PostgreSQL is installed, you need to create a new user (you can do this from pgAdmin 'Login Roles' in the tree):
+* [PostgreSQL](http://www.postgresql.org/) version 9.4 - see [here](https://wiki.postgresql.org/wiki/Detailed_installation_guides) for installation instructions for your platform. You also may want to install the [pgAdmin](http://www.pgadmin.org/).
+
+* "Cube" PostgreSQL extension may be installed together with PostgreSQL, if not, you have to install it by yourself (e.g. in Debian/Ubuntu You may need to follow [these steps](http://askubuntu.com/a/354709)).
+
+* When PostgreSQL is installed, you need to create a new user (you can do this from pgAdmin 'Login Roles' in the tree):
   * username: platform
   * password: QdYx3D5y
 


### PR DESCRIPTION
was causing the following error when running `./localdev.js run zen`: 

````
Error running service: Error running command: node ./service.js - Error: Command failed: { [error: could not open extension control file "/usr/share/postgresql/9.4/extension/cube.control": No such file or directory]
  name: 'error',
  length: 297,
  severity: 'ERROR',
  code: '58P01',
  detail: undefined,
  hint: undefined,
  position: undefined,
  internalPosition: undefined,
  internalQuery: undefined,
  where: 'SQL statement "CREATE EXTENSION IF NOT EXISTS cube"\nPL/pgSQL function inline_code_block line 4 at SQL statement',
  file: 'extension.c',
  line: '474',
  routine: 'parse_extension_control_file' }
````