### PR TITLE
added cp-e2e-tests to localdev.js init zen

### DIFF
--- a/run.js
+++ b/run.js
@@ -49,6 +49,7 @@ module.exports = function (argv, systems, cb) {
   }
 
   function runService (service, cb) {
+    if (!service.start) return cb();
     var dir = workspace + '/' + service.name;
     var cmd = service.start;
     debug('runService', dir, cmd);

--- a/system.js
+++ b/system.js
@@ -63,6 +63,9 @@ module.exports = {
       }, {
         name: 'cp-zen-platform',
         ignored: ['web/.build']
+      }, {
+        name: 'cp-e2e-tests',
+        start: null
       }];
 
       // add default getter props to all services if not already overridden
@@ -98,20 +101,20 @@ var env = function (system) {
 
 var addGetters = function (services, self) {
   _.each(services, function (service) {
-    if (!service.repo) {
+    if (service.repo === undefined) {
       service.__defineGetter__('repo', function () {
         return baseRepo + service.name;
       });
     }
     var serviceBranch = service.branch;
-    if (!service.branch) {
+    if (service.branch === undefined) {
       service.__defineGetter__('branch', function () {
         return serviceBranch || self.systemBranch || defaultBranch;
       });
     }
 
     // most services have the same start command
-    if (!service.start) {
+    if (service.start === undefined) {
       service.__defineGetter__('start', function () {
         return 'node ./service.js';
       });


### PR DESCRIPTION
This clones the cp-e2e-tests repository into the workspace-zen directory.