### PR TITLE
Alternative solution for env:node no such file.

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -29,7 +29,7 @@ This can often be due to a connection issue with Github - please try reinstallin
 
 ## Mac
 * If you are running a Mac you will need to have xcode installed. You can install this via the app store on OSX.
-* If you come across the error: ```env: node\r: No such file or directory``` when running ```./localdev.js```, you need to make sure the file ending for ```./localdev.js``` is in Unix ending. You may also run into similar problem when loading test data later using ```./localdev.js testdata zen```. If that happens, make sure all the ```exec_on_env.sh``` and ```load_test_data.sh``` files under the project are in Unix ending before running ```./localdev.js testdata zen```. 
+* If you come across the error: ```env: node\r: No such file or directory``` when running ```./localdev.js```, you need to make sure the file ending for ```./localdev.js``` is in Unix ending. You may also run into similar problem when loading test data later using ```./localdev.js testdata zen```. If that happens, make sure all the ```exec_on_env.sh``` and ```load_test_data.sh``` files under the project are in Unix ending before running ```./localdev.js testdata zen```. If you get env: node: No such file or directory while running ```./localdev.js testdata zen```, it can also be caused if the node alias was never set during installation. You will need to run ```nvm alias default 0.x.x``` after installing node, so the shell will remember the node env.
 
 - - - -
 


### PR DESCRIPTION
All the files were in unix ending for me, but I still got the env: node no such file or directory error. The solution was to set the nvm alias default as it never happened during installation.