### PR TITLE
Update README to remove localdev and testdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ Run:
 
 ```
 git clone https://github.com/CoderDojo/cp-local-development.git && cd cp-local-development
+# this will clone all the microservices
 ./setup_repo.sh
+# this will install the dependencies of all microservices
 ./install_deps.sh
 ```
 
@@ -46,8 +48,6 @@ ownership to yourself.
 
 To first set up the local development environment run, from the
 cp-local-development folder, `docker-compose up zen`.
-Once zen has loaded then `docker-compose up testdata` to load testdata.
-This will build the containers and add the test data.
 To start zen from then on you just have to run
 
 ```
@@ -60,7 +60,7 @@ To restart a container run
 docker-compose restart $service
 ```
 
-To Stop the containers just run.
+To stop the containers run.
 
 ```
 docker-compose stop
@@ -71,36 +71,13 @@ e.g. `docker-compose up dojos`. Once docker looks to be running all the
 services ok (you'll see a lot of stack traces in the output if they are not
 running ok!) you should be able to hit [`localhost:8000`](http://localhost:8000)
 in your browser. If this is your first time running, you should see the "Find
-a Dojo to attend" Page this page wont return any dojos till you load testdata
+a Dojo to attend" Page this page wont return any dojos until you've created one 
 
 Note that the Forums and [Badges](installing-badgekit.md) will not be operable
 in local development mode, to run these, you need to install both
-[NodeBB](https://nodebb.org) and [BadgeKit](installing-badgekit.md) locally.
-
-## Test Data
-
-To reload the test data just run
-`docker-compose down -v && docker-compose up testdata`. This will delete the current
-database and reload all testdata. When all the test data is loaded, you should
-see Dojos appearing when you refresh your home page.
-The different users you can login with are listed in [this file](https://github.com/CoderDojo/cp-users-service/blob/master/test/fixtures/e2e/README.md)
-
-## End to End Tests
-
-You can run the e2e tests by running `docker-compose run --rm test`
-It means, it'll wipe your test database and start the e2e tests.
+[NodeBB](https://nodebb.org) and [BadgeKit](installing-badgekit.md) locally, which are a different problem.
 
 ## Making code changes and working locally
-
-When you initialise a system, it creates a `workspace-<systemName>` folder for
-each system, e.g. `workspace-zen`. If you open this directory in your code editor
-you will see all the code repositories that make up this system, e.g. cp-zen-platform,
-cp-dojos-service, cp-users-service, cp-countries-service, etc. When you first set
-it up, the `init` command will checkout the default branch for that system, e.g.
-`my-zen-branch` for each service. From then on, it's up to you to manage the
-contents of this directory, e.g. creating branches, changing branches, etc.
-The `run` command will simply run whatever is in those directories, it doesn't
-care about what branch they're on, etc.
 
 ### Creating your own forks
 
@@ -110,19 +87,27 @@ care about what branch they're on, etc.
   pull request into the parent repository at CoderDojo/cp-zen-platform.
   [Read more about forks here](https://help.github.com/articles/fork-a-repo/).
 * You will need to fork:
-  * [cp-zen-platform](https://github.com/CoderDojo/cp-zen-platform) legacy
-    frontend and api repo
+  * [cp-zen-platform](https://github.com/CoderDojo/cp-zen-platform) (legacy
+    frontend and) api repo
   * [cp-zen-frontend](https://github.com/CoderDojo/cp-zen-frontend) frontend repo
-  * [cp-dojos-service](https://github.com/CoderDojo/cp-dojos-service) backend repo,
+  * [cp-dojos-service](https://github.com/CoderDojo/cp-dojos-service) legacy backend repo,
     service for Dojos
-  * [cp-events-service](https://github.com/CoderDojo/cp-events-service) backend
+  * [cp-events-service](https://github.com/CoderDojo/cp-events-service) legacy backend
     repo, service for events
-  * [cp-users-service](https://github.com/CoderDojo/cp-users-service) backend repo,
+  * [cp-users-service](https://github.com/CoderDojo/cp-users-service) legacy backend repo,
     service for users
   * [cp-eventbrite-service](https://github.com/CoderDojo/cp-eventbrite-service)
     backend service for eventbrite integration
   * [cp-organisations-service](https://github.com/CoderDojo/cp-organisations-service)
     backend service for user groups
+  * [cp-email-service](https://github.com/CoderDojo/cp-email-service)
+    backend service for mailing
+  * [events-service](https://github.com/CoderDojo/events-service)
+    backend service for events 
+  * [users-service](https://github.com/CoderDojo/users-service)
+    backend service for users 
+  * [clubs-service](https://github.com/CoderDojo/clubs-service)
+    backend service for clubs 
 
 You can read more about the repositories and system architecture [in this document](https://github.com/CoderDojo/community-platform/blob/master/architecture.md).
 
@@ -144,7 +129,7 @@ Then, a typical development workflow would be:
 ```
 $ cd ./workspace-zen/cp-zen-platform
 $ git checkout -b my-new-branch
-$ # make changes to code in your editor of choice. Any time code changes in a service the `run` command will automatically reload the service
+$ # make changes to code in your editor of choice.
 $ git push -u local my-new-branch
 $ # to pull request, code review, merge, etc on github
 ```
@@ -163,55 +148,15 @@ $ # like a "git pull --rebase"
 $ git rebase origin/master
 ```
 
-## The `localdev` tool
+## Debug
 
-This tool is designed to make it as easy as possible to on-board new developers
-to the Community Platform. It is also designed to be cross platform, so
-developers can contribute to the community on their OS of choice, e.g. Windows,
-Mac & Linux.
-
-The [system.js](system.js) file is a mixture of code and data, and it's where
-the 'systems' are defined (just 'zen' now). At its core, each System contains a
-set of Services, and each service has its own code repository on github. When
-each command starts, it prints out the full information of the system it's using,
-e.g.
-
+Most of the new services are exposing an interface to the node debugger, which are described by the following:
 ```
-zen: {
-  services: [{
-    name: 'cp-dojos-service',
-    test: {
-      name: 'test-dojo-data',
-      port: 11301,
-      host: process.env.CD_DOJOS || 'localhost',
-    },
-...
+  ports:
+   - 92xx:9229
 ```
-
-### Environment values
-
-`localdev` has four places where environment variables can be set:
-
-* env vars that are global to all systems, these are read first
-* env vars that are system specific, these are read next
-* env vars that are service specific, these are read next
-* local setup specific variables, these are read last
-
-Settings at any level will override existing settings, so for example anything
-you set in your local setup will override any previous setting.
-
-See [system.js](system.js) for global, system and service environment variables.
-
-To set local environment variables, set them in the `docker-compose.yml`:
-
-### Debug
-
-`localdev` uses the [Debug](http://npm.im/debug) module, to get extra debug
-information, run commands prefixed with 'DEBUG=localdev:* ..', e.g.
-
-```
-DEBUG=localdev:* ./localdev.js run zen
-```
+The ports are incremental and in the 9200-9300 range.
+To open the debugger, open chrome with chrome://inspect.
 
 ## Troubleshooting
 


### PR DESCRIPTION
It's not "that" simpler (as we clearly lost e2e test data), but it removes the dead part of the README