### PR TITLE
Attach to profile network if available

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,8 @@
 version: '3.3'
+networks:
+  default:
+    external:
+      name: profile_default
 services:
   db:
     build: ./cd-db
@@ -8,6 +12,8 @@ services:
       - ./cd-db/dumps:/db
     environment:
       - POSTGRES_PASSWORD=QdYx3D5y
+    ports:
+      - '5433:5432'
   kue:
     image: redis:3-alpine
     restart: always


### PR DESCRIPTION
Related to CoderDojo/cp-zen-platform#1382

Attach to profile network if available, so auth hydra service can be directly addressed as `auth` by `cp-users-service` when cashing in auth callback for rpi user token.

Expose db port for local debugging