### PR TITLE
Amend restore script

### DIFF
--- a/cd-db/restore_db.sh
+++ b/cd-db/restore_db.sh
@@ -12,7 +12,19 @@ restore() {
     echo restoring "$DUMP"
     mkdir -p /db/"$repo"
     tar xvf "$DUMP" -C /db/"$repo"
-    pg_restore -c --if-exists -w -d "cp-${repo}-development" -U platform /db/"$repo"/backup_dump
+    if [ "$repo" == dojos ]; then
+      echo creating dojos restore list file
+      pg_restore --list /db/dojos/backup_dump -f /db/dojos.list
+
+      echo removing nearest_dojos index from dojos restore list
+      sed -i -e '/nearest_dojos/d' /db/dojos.list
+
+      echo restoring using list file
+      pg_restore -c --if-exists -w -d "cp-${repo}-development" -U platform -L /db/dojos.list /db/"$repo"/backup_dump
+    else
+      echo restoring "$DUMP" with pg_restore
+      pg_restore -c --if-exists -w -d "cp-${repo}-development" -U platform /db/"$repo"/backup_dump
+    fi
   fi
 }
 


### PR DESCRIPTION
PSQL changes require namespacing of extensions and this breaks the
import of dumps exported from the dojos database.

Remove the index that causes this issue when restoring the dojos
database.