### PR TITLE
65: Updating Postgres container version to match changes being made to prod.

### DIFF
--- a/cd-db/Dockerfile
+++ b/cd-db/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9-alpine
+FROM postgres:11-alpine
 LABEL maintainer="butlerx <cian@coderdojo.org>"
 RUN mkdir -p /db && chown -R postgres:postgres /db
 VOLUME /db

--- a/cd-db/anon_db.sql
+++ b/cd-db/anon_db.sql
@@ -14,9 +14,6 @@ TRUNCATE cd_oauth2;
 UPDATE cd_profiles SET name = 'Namey McNameFace';
 UPDATE cd_profiles SET email = 'testmail+user' || user_id || '@example.com';
 UPDATE cd_profiles SET alias = 'NameyFace';
-UPDATE cd_profiles SET
-  address = '123 Fake St., Over There Ave., End of the Road',
-  phone = translate(phone, '0123456789','9999999999');
 UPDATE cd_profiles SET avatar = NULL, parent_invites = NULL, ninja_invites = NULL, twitter = NULL, linkedin = NULL;
 UPDATE sys_login SET email = 'testmail+user' || sys_login.user || '@example.com', token = NULL;
 UPDATE sys_login SET nick = email;

--- a/cd-db/restore_db.sh
+++ b/cd-db/restore_db.sh
@@ -2,20 +2,36 @@
 
 set -e
 
-# To restore the a database place the tar.gz in the dump folder
-# they should be called users.tar.gz, dojos.tar.gz and events.tar.gz
+# To restore the a database place an unzipped tar in the dump folder
+# they should be called users.tar, dojos.tar and events.tar
+# or untar a backup of each db into it's corresponding folder users, dojos or events
+# Don't use a gzipped backup as tar will fail
+# FYI Database dumps are stored in an S3 bucket called zen-pg-backup
 
 restore() {
   repo=$1
-  DUMP="/db/${repo}.tar.gz"
+  DUMP="/db/${repo}.tar"
   if [ -f "$DUMP" ]; then
-    echo restoring "$DUMP"
+    echo unpacking "$DUMP"
     mkdir -p /db/"$repo"
     tar xvf "$DUMP" -C /db/"$repo"
+  fi
+  DIR="/db/${repo}/backup_dump"
+  if [ -d "$DIR" ]; then
+    echo restoring "$repo"
     pg_restore -c --if-exists -w -d "cp-${repo}-development" -U platform /db/"$repo"/backup_dump
   fi
 }
 
 restore users
-restore dojos
 restore events
+# dojos may fail when creating the index for nearest_dojos on backups from Posgres 9.4
+# Restart the container and you can run it manually if needed
+# `docker exec -it cp-local-development_db_1 bash`
+# Start a psql console
+# psql -U postgres
+# Change to dojos DB
+# \c cp-dojos-development
+# Execute the SQL
+# CREATE INDEX nearest_dojos ON public.cd_dojos USING gist (public.ll_to_earth((((geo_point -> 'lat'::text))::text)::double precision, (((geo_point -> 'lon'::text))::text)::double precision));
+restore dojos

--- a/cd-db/setup_zen.sql
+++ b/cd-db/setup_zen.sql
@@ -1,3 +1,10 @@
+-- Until the SUPERUSER role is removed from dumps
+CREATE ROLE d8jnawwrcw7sp9 SUPERUSER;
+-- END
+-- Dojos DB requires some extensions
+CREATE EXTENSION cube;
+CREATE EXTENSION earthdistance;
+-- END
 create user platform with superuser password 'QdYx3D5y';
 CREATE DATABASE "cp-dojos-development" OWNER platform;
 CREATE DATABASE "cp-users-development" OWNER platform;


### PR DESCRIPTION
Updating Postgres from v9 -> v11 requires a couple of changes around the earthdistance extension.  Data can't be reloaded because of a mismatch in extension versions so an index needs to be dropped before migration and (optionally) re-instated after. 
- Update Docker container to Postgres 11
- Add superuser to setup
- Add creating of extensions to setup
- Split untar and restore in the restore script allowing us to work with existing directories
- Change order so that dojos (which may fail) goes last
- Remove insert for address column that no longer exists from anon sql