### PR TITLE
Refactor how environment variables are set

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,20 @@
+################################
+# Stuff that you'll want to edit
+
+# Eventbrite API: See notes in the README about this.
+# Client secret 
+EVENTBRITE_SECRET_KEY=
+# API key 
+EVENTBRITE_PUBLIC_KEY=
+# Not sure what this does. Possibly a shared secret for use in the oauth process.
+EVENTBRITE_HASH_KEY=correct-horse-battery-staple
+
+# Get this from https://console.cloud.google.com/google/maps-apis/credentials
+GOOGLE_MAPS_KEY=
+
+###############################################
+# Probably don't need to edit stuff after here.
+
 CDF_ADMINS=john.doe@example.com,jane.doe@example.com
 CD_BADGES=badges
 CD_DOJOS=dojos
@@ -9,15 +26,6 @@ EMAIL_DEFAULT_FROM='The CoderDojo Team <info@coderdojo.org>'
 EMAIL_SERVICE=email
 EVENTS_SERVICE=events-service
 EVENT_URL=http://localhost:8000/events/
-# Eventbrite API: get these details from https://www.eventbrite.com/myaccount/apps/
-# Client secret 
-EVENTBRITE_SECRET_KEY=
-# API key 
-EVENTBRITE_PUBLIC_KEY=
-# Not sure what this does. Possibly a shared secret for use in the oauth process.
-EVENTBRITE_HASH_KEY=correct-horse-battery-staple
-# Get this from https://console.cloud.google.com/google/maps-apis/credentials
-GOOGLE_MAPS_KEY=
 ICS_EVENT_URL=http://localhost:8000/api/3.0/events/
 KUE_HOST=kue
 KUE_REQUIRED='true'

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+CDF_ADMINS=john.doe@example.com,jane.doe@example.com
+CD_BADGES=badges
+CD_DOJOS=dojos
+CD_EVENTBRITE=eventbrite
+CD_EVENTS=events
+CD_ORGANISATIONS=organisations
+CD_USERS=users
+EMAIL_DEFAULT_FROM='The CoderDojo Team <info@coderdojo.org>'
+EMAIL_SERVICE=email
+EVENTS_SERVICE=events-service
+EVENT_URL=http://localhost:8000/events/
+# Eventbrite API: get these details from https://www.eventbrite.com/myaccount/apps/
+# Client secret 
+EVENTBRITE_SECRET_KEY=
+# API key 
+EVENTBRITE_PUBLIC_KEY=
+# Not sure what this does. Possibly a shared secret for use in the oauth process.
+EVENTBRITE_HASH_KEY=correct-horse-battery-staple
+# Get this from https://console.cloud.google.com/google/maps-apis/credentials
+GOOGLE_MAPS_KEY=
+ICS_EVENT_URL=http://localhost:8000/api/3.0/events/
+KUE_HOST=kue
+KUE_REQUIRED='true'
+MAILDEV_ENABLED=true
+MICROSERVICE_PORT=3000
+NODE_ENV=development
+POSTGRES_HOST=db
+POSTGRES_PASSWORD=QdYx3D5y
+SMTP_HOST=maildev
+SMTP_PORT=25
+SMTP_SECURE=false
+TEMPLATES_DIR=/usr/src/app/node_modules/cp-translations/email-templates
+TRANSPORT=smtp
+URL_BASE=http://localhost:8000

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 *.log*
 cd-db/dumps/*
 !cd-db/dumps/.gitkeep
+.env

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ Note that the Forums and [Badges](installing-badgekit.md) will not be operable
 in local development mode, to run these, you need to install both
 [NodeBB](https://nodebb.org) and [BadgeKit](installing-badgekit.md) locally, which are a different problem.
 
+
+## Evironent settings
+
+All these are in the `.env.example` file, which should be copied to `.env`.
+Once copied, you'll want to fill in some of the details.  Currently you'll need
+keys for Google Maps and Eventbrite.
+
 ## Making code changes and working locally
 
 ### Creating your own forks
@@ -188,4 +195,7 @@ In order to get your changes deployed there might be several merges/upgrades to 
 This is because both `cp-zen-frontent` and `cp-zen-platform` independently depend on `cp-translations`, and then `cp-zen-platform` also depends on `cp-zen-frontend`.
 
 You might find other dependency chains that are similar, so be aware that you might have to merge before updating dependent repos.
+
+
+
 

--- a/README.md
+++ b/README.md
@@ -83,12 +83,22 @@ Note that the Forums and [Badges](installing-badgekit.md) will not be operable
 in local development mode, to run these, you need to install both
 [NodeBB](https://nodebb.org) and [BadgeKit](installing-badgekit.md) locally, which are a different problem.
 
-
-## Evironent settings
+## Environment settings
 
 All these are in the `.env.example` file, which should be copied to `.env`.
 Once copied, you'll want to fill in some of the details.  Currently you'll need
-keys for Google Maps and Eventbrite.
+keys for 
+[Google Maps](https://console.cloud.google.com/google/maps-apis/credentials)
+and [Eventbrite](https://www.eventbrite.ie/myaccount/apps/).
+
+When making changes to your `.env` file, you'll want to run 
+`docker-compose up -d` to ensure environment changes are propagated to the
+appropriate containers.
+
+**NB** when configuring your Eventbrite API key, you'll need to set the 
+*OAuth Redirect URI* on the Key Info page to
+`http://localhost:8000/dashboard/edit-dojo-eventbrite` otherwise you'll get a
+message about no `redirect_uri` parameter being supplied when connecting.
 
 ## Making code changes and working locally
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - pg-data:/data/postgres
       - ./cd-db/dumps:/db
     environment:
-      - POSTGRES_PASSWORD=QdYx3D5y
+      - POSTGRES_PASSWORD
     ports:
       - '5434:5432'
   kue:
@@ -22,7 +22,9 @@ services:
     working_dir: /usr/src/app
     ports:
       - '8000:8000'
-    env_file: ./workspace-zen/cp-zen-platform/web/config/development.env
+    env_file:
+      - ./workspace-zen/cp-zen-platform/web/config/development.env
+      - ./.env
     command: yarn dev
     depends_on:
       - users
@@ -38,16 +40,17 @@ services:
       - maildev
       - email
     environment:
-      - CD_USERS=users
-      - CD_DOJOS=dojos
-      - CD_EVENTS=events
-      - CD_BADGES=badges
-      - CD_EVENTBRITE=eventbrite
-      - CD_ORGANISATIONS=organisations
-      - EVENTS_SERVICE=events-service
-      - EMAIL_SERVICE=email
-      - NODE_ENV=development
-      - MAILDEV_ENABLED=true
+      - CD_USERS
+      - CD_DOJOS
+      - CD_EVENTS
+      - CD_BADGES
+      - CD_EVENTBRITE
+      - CD_ORGANISATIONS
+      - EVENTS_SERVICE
+      - EMAIL_SERVICE
+      - GOOGLE_MAPS_KEY
+      - NODE_ENV
+      - MAILDEV_ENABLED
     volumes:
       - ./workspace-zen/cp-zen-platform:/usr/src/app:Z
       - ./workspace-zen/cp-zen-frontend:/usr/src/app/node_modules/cp-zen-frontend:ro
@@ -57,26 +60,27 @@ services:
     command: yarn dev
     working_dir: /usr/src/app
     environment:
-      - NODE_ENV=development
+      - NODE_ENV
     volumes:
       - ./workspace-zen/cp-zen-frontend:/usr/src/app:Z
       - ./workspace-zen/cp-translations:/usr/src/app/node_modules/cp-translations:ro
   dojos:
     image: node:carbon
-    env_file: ./workspace-zen/cp-dojos-service/config/development.env
+    env_file:
+      - ./workspace-zen/cp-dojos-service/config/development.env
+      - ./.env
     working_dir: /usr/src/app
     command: yarn dev
     environment:
-      - NODE_ENV=development
-      - CD_USERS=users
-      - CD_EVENTS=events
-      - CD_BADGES=badges
-      - CD_ORGANISATIONS=organisations
-      - POSTGRES_HOST=db
-      - KUE_REQUIRED='true'
-      - KUE_HOST=kue
-      - GOOGLE_MAPS_KEY=AIzaSyAWA2gcHWQsS7Snr_p86QUxGwM0hBn95pQ
-      - MAILDEV_ENABLED=true
+      - NODE_ENV
+      - CD_USERS
+      - CD_EVENTS
+      - CD_BADGES
+      - CD_ORGANISATIONS
+      - POSTGRES_HOST
+      - KUE_REQUIRED
+      - KUE_HOST
+      - MAILDEV_ENABLED
     depends_on:
       - db
       - kue
@@ -85,17 +89,19 @@ services:
       - ./workspace-zen/cp-translations:/usr/src/app/node_modules/cp-translations:ro
   users:
     image: node:carbon
-    env_file: ./workspace-zen/cp-users-service/config/development.env
+    env_file:
+      - ./workspace-zen/cp-users-service/config/development.env
+      - ./.env
     working_dir: /usr/src/app
     command: yarn dev
     environment:
-      - NODE_ENV=development
-      - CD_DOJOS=dojos
-      - CD_EVENTS=events
-      - CD_BADGES=badges
-      - POSTGRES_HOST=db
-      - CDF_ADMINS=admin@coderdojo.org,daniel@coderdojo.org
-      - MAILDEV_ENABLED=true
+      - NODE_ENV
+      - CD_DOJOS
+      - CD_EVENTS
+      - CD_BADGES
+      - POSTGRES_HOST
+      - CDF_ADMINS
+      - MAILDEV_ENABLED
     depends_on:
       - db
     volumes:
@@ -103,17 +109,19 @@ services:
       - ./workspace-zen/cp-translations:/usr/src/app/node_modules/cp-translations:ro
   events:
     image: node:carbon
-    env_file: ./workspace-zen/cp-events-service/config/development.env
+    env_file:
+      - ./workspace-zen/cp-events-service/config/development.env
+      - ./.env
     working_dir: /usr/src/app
     command: yarn dev
     environment:
-      - CD_USERS=users
-      - CD_DOJOS=dojos
-      - CD_BADGES=badges
-      - NODE_ENV=development
-      - POSTGRES_HOST=db
-      - KUE_REQUIRED='true'
-      - KUE_HOST=kue
+      - CD_USERS
+      - CD_DOJOS
+      - CD_BADGES
+      - NODE_ENV
+      - POSTGRES_HOST
+      - KUE_REQUIRED
+      - KUE_HOST
     depends_on:
       - db
       - kue
@@ -122,25 +130,29 @@ services:
   badges:
     image: node:carbon
     working_dir: /usr/src/app
-    env_file: ./workspace-zen/cp-badges-service/config/development.env
+    env_file:
+      - ./workspace-zen/cp-badges-service/config/development.env
+      - ./.env
     command: yarn dev
     environment:
-      - CD_USERS=users
-      - CD_DOJOS=dojos
-      - CD_EVENTS=events
-      - NODE_ENV=development
+      - CD_USERS
+      - CD_DOJOS
+      - CD_EVENTS
+      - NODE_ENV
     volumes:
       - ./workspace-zen/cp-badges-service:/usr/src/app:Z
       - ./workspace-zen/cp-translations:/usr/src/app/node_modules/cp-translations:ro
   eventbrite:
     image: node:carbon
     command: yarn dev
-    env_file: ./workspace-zen/cp-eventbrite-service/config/development.env
+    env_file:
+      - ./workspace-zen/cp-eventbrite-service/config/development.env
+      - ./.env
     working_dir: /usr/src/app
     environment:
-      - CD_DOJOS=dojos
-      - CD_EVENTS=events
-      - NODE_ENV=development
+      - CD_DOJOS
+      - CD_EVENTS
+      - NODE_ENV
     volumes:
       - ./workspace-zen/cp-eventbrite-service:/usr/src/app:Z
       - ./workspace-zen/cp-translations:/usr/src/app/node_modules/cp-translations:ro
@@ -148,11 +160,13 @@ services:
     image: node:carbon
     command: yarn dev
     working_dir: /usr/src/app
-    env_file: ./workspace-zen/cp-organisations-service/config/development.env
+    env_file:
+      - ./workspace-zen/cp-organisations-service/config/development.env
+      - ./.env
     environment:
-      - CD_USERS=users
-      - NODE_ENV=development
-      - POSTGRES_HOST=db
+      - CD_USERS
+      - NODE_ENV
+      - POSTGRES_HOST
     depends_on:
       - db
     volumes:
@@ -165,8 +179,8 @@ services:
     depends_on:
       - db
     environment:
-      - ICS_EVENT_URL=http://localhost:8000/api/3.0/events/
-      - EVENT_URL=http://localhost:8000/events/
+      - ICS_EVENT_URL
+      - EVENT_URL
     volumes:
       - ./workspace-zen/services/events-service:/usr/src/app:Z
   maildev:
@@ -178,14 +192,14 @@ services:
     command: yarn dev
     working_dir: /usr/src/app
     environment:
-      - URL_BASE=http://localhost:8000
-      - EMAIL_DEFAULT_FROM='The CoderDojo Team <info@coderdojo.org>'
-      - MICROSERVICE_PORT=3000
-      - TRANSPORT=smtp
-      - SMTP_HOST=maildev
-      - TEMPLATES_DIR=/usr/src/app/node_modules/cp-translations/email-templates
-      - SMTP_SECURE=false
-      - SMTP_PORT=25
+      - URL_BASE
+      - EMAIL_DEFAULT_FROM
+      - MICROSERVICE_PORT
+      - TRANSPORT
+      - SMTP_HOST
+      - TEMPLATES_DIR
+      - SMTP_SECURE
+      - SMTP_PORT
     volumes:
       - ./workspace-zen/services/cp-email-service:/usr/src/app:Z
       - ./workspace-zen/cp-translations:/usr/src/app/node_modules/cp-translations:ro


### PR DESCRIPTION
This is to avoid sensitive keys being checked into source control.  I've specified the `.env` file after the application supplied config, so we can overwrite what the application has provided.

This also adds some detail around the Eventbrite config, especially around the redirect URI param.